### PR TITLE
update arrow-vector to 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
             <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjrt</artifactId>
-                <version>1.8.9</version>
+                <version>1.9.6</version>
             </dependency>
 
             <dependency>
@@ -307,7 +307,7 @@
             <dependency>
                 <groupId>org.apache.arrow</groupId>
                 <artifactId>arrow-vector</artifactId>
-                <version>1.0.0</version>
+                <version>6.0.0</version>
                 <scope>compile</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
update the version of  "org.apache.arrow.arrow-vector" from "1.0.0" to "6.0.0". 

**note**,  the projects who use both "aliyun-odps-java-sdk" and  "apache arrow" should update arrow dependencies like "arrow-memory-netty" to "6.0.0" too. Otherwise, the there well be a "arrow-core" dependency conflict.