### PR TITLE
revert protobuf version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.21.12</version>
+                <version>2.4.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
由于pb3不完全兼容pb2，回滚protobuf版本