### PR TITLE
Make human-readable formatting thread-safe

### DIFF
--- a/odps-sdk/odps-sdk-commons/src/main/java/com/aliyun/odps/utils/StringUtils.java
+++ b/odps-sdk/odps-sdk-commons/src/main/java/com/aliyun/odps/utils/StringUtils.java
@@ -99,7 +99,8 @@ public class StringUtils {
     return fullHostname;
   }
 
-  private static DecimalFormat oneDecimal = new DecimalFormat("0.0");
+  private static final ThreadLocal<DecimalFormat> ONE_DECIMAL =
+      ThreadLocal.withInitial(() -> new DecimalFormat("0.0"));
 
   /**
    * Given an integer, return a string that is in an approximate, but human
@@ -126,7 +127,7 @@ public class StringUtils {
       result = number / (1024.0 * 1024 * 1024);
       suffix = "G";
     }
-    return oneDecimal.format(result) + suffix;
+    return ONE_DECIMAL.get().format(result) + suffix;
   }
 
   /**


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/801987.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Store DecimalFormat per thread because DecimalFormat is mutable and StringUtils can be called concurrently.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
